### PR TITLE
fix: zunderscore/chocolatey-packages#4

### DIFF
--- a/cascadia/chocolateyinstall.ps1
+++ b/cascadia/chocolateyinstall.ps1
@@ -4,16 +4,19 @@ $packageArgs = @{
   packageName   = '{{packageName}}'
 }
 
-Write-Output "Attempting to uninstall previous version of {{displayName}} font..."
+$windowsFonts = $env:SystemRoot + '\Fonts'
 
-if ((Uninstall-ChocolateyFont "{{filename}}") -eq 1) {
-    Write-Warning "Error uninstalling previous version of {{displayName}} font"
-} else {
-    Write-Output "Previous version of {{displayName}} font uninstalled successfully"
+$font = $windowsFonts + '\{{filename}}'
+if (Test-Path $font) { # Check if the file actually exists
+    Write-Output "Attempting to uninstall previous version of {{displayName}} font..."
+    if ((Uninstall-ChocolateyFont "{{filename}}") -eq 1) {
+        Write-Warning "Error uninstalling previous version of {{displayName}} font"
+    } else {
+        Write-Output "Previous version of {{displayName}} font uninstalled successfully"
+    }
 }
 
 Write-Output "Installing {{displayName}} font..."
-
 if ((Install-ChocolateyFont "$env:ChocolateyInstall\lib\{{packageName}}\files\{{filename}}") -eq 1) {
     Write-Error "Error installing {{displayName}} font"
 } else {

--- a/cascadia/chocolateyuninstall.ps1
+++ b/cascadia/chocolateyuninstall.ps1
@@ -4,18 +4,21 @@ $packageArgs = @{
   packageName   = '{{packageName}}'
 }
 
+$windowsFonts = $env:SystemRoot + '\Fonts'
+
 if ("{{legacyFilename}}" -ne "{{filename}}") {
-    Write-Output "Uninstalling legacy {{displayName}} font..."
-    
-    if ((Uninstall-ChocolateyFont "{{legacyFilename}}") -eq 1) {
-        Write-Error "Error uninstalling legacy {{displayName}} font"
-    } else {
-        Write-Output "Legacy {{displayName}} font uninstalled successfully"
+    $fontLegacy = $windowsFonts + '\{{legacyFilename}}'
+    if (Test-Path $fontLegacy) { # Check if the file actually exists
+        Write-Output "Uninstalling legacy {{displayName}} font..."
+        if ((Uninstall-ChocolateyFont "{{legacyFilename}}") -eq 1) {
+            Write-Error "Error uninstalling legacy {{displayName}} font"
+        } else {
+            Write-Output "Legacy {{displayName}} font uninstalled successfully"
+        }
     }
 }
 
 Write-Output "Uninstalling {{displayName}} font..."
-
 if ((Uninstall-ChocolateyFont "{{filename}}") -eq 1) {
     Write-Error "Error uninstalling {{displayName}} font"
 } else {


### PR DESCRIPTION
This change adds a test that will check if the font file to be uninstalled actually exists in the system. If the file does not exist in the system, the uninstaller skips the step of trying to uninstall that font file and giving a non-zero error because the file does not exist in the system.

`$windowsFonts` variable would ideally point to `C:\Windows\Fonts`.
`$env:SystemRoot` ideally points to `C:\Windows`.